### PR TITLE
Reproduction for https://github.com/runatlantis/atlantis/issues/3917

### DIFF
--- a/modules/c/main.tf
+++ b/modules/c/main.tf
@@ -1,3 +1,7 @@
 resource "null_resource" "example" {
 
 }
+
+resource "null_resource" "example2" {
+
+}


### PR DESCRIPTION
This PR demonstrates a reproduction for https://github.com/runatlantis/atlantis/issues/3917

I expect that, with `autoplan-modules` on, a change to a module will create plans for the projects that use it. This does work, but it stops working when you also add `skip-clone-no-changes`.